### PR TITLE
feat: migrate CLI from Abseil to Typer with environment file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@
 
 ## Unreleased
 
+### Changed
+- **BREAKING**: Migrated CLI from Abseil to Typer with command groups and subcommands
+  - Command structure now uses groups: `logstory usecases COMMAND` and `logstory replay COMMAND`
+  - Flag names changed to use hyphens: `--customer-id` instead of `--customer_id`
+  - Improved help system with auto-generated documentation
+  - Better error handling and validation
+  - See README.md for command migration guide
+- Improved `list-installed` command with better default behavior
+  - Default now shows just usecase names (clean and scannable)
+  - `--details` flag shows full markdown content (previous default behavior)
+  - `--logtypes` flag shows logtypes with clean indentation
+
 ### Added
+- `--open` flag for `usecases list-installed` to open markdown files in VS Code
+- `--details` flag for `usecases list-installed` to show full markdown content
+- Environment file support with `--env-file` option for configuration management
+- Support for environment variables: `LOGSTORY_CUSTOMER_ID`, `LOGSTORY_CREDENTIALS_PATH`, `LOGSTORY_REGION`
+- Automatic loading of `.env` file if present in working directory
+- Multiple environment configuration support (e.g., `.env.prod`, `.env.dev`)
 - Comprehensive pre-commit hooks configuration for code quality
   - Python linting with ruff
   - Python formatting with pyink (2-space indentation)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,22 +19,22 @@ Logstory has a command line interface (CLI), written in Python, that is most eas
 $ pip install logstory
 ```
 
-The `logstory` CLI interface has subcommands, which take arguments like so:
+The `logstory` CLI interface uses command groups and subcommands with arguments like so:
 ```
-logstory usecase_replay RULES_SEARCH_WORKSHOP
+logstory replay usecase RULES_SEARCH_WORKSHOP
 ```
 
 These are explained in depth later in this doc.
 
 ## Configuration
 
-After the subcommand, Logstory uses Google's [Abseil](https://abseil.io/docs/python/quickstart.html) library for parameterization of the CLI (aka "flags"). Once installed, it is easiest to configure the CLI flags in an [Abseil flagfile](https://abseil.io/docs/python/guides/flags#a-note-about---flagfile) like this one:
+After the subcommand, Logstory uses [Typer](https://typer.tiangolo.com/) for modern CLI argument and option handling. You can pass options directly on the command line like this:
 
 ```
-logstory usecase_replay RULES_SEARCH_WORKSHOP \
---customer_id=01234567-0123-4321-abcd-01234567890a \
---credentials_path=/usr/local/google/home/dandye/.ssh/malachite-787fa7323a7d_bk_and_ing.json \
---timestamp_delta=1d  # optional
+logstory replay usecase RULES_SEARCH_WORKSHOP \
+  --customer-id=01234567-0123-4321-abcd-01234567890a \
+  --credentials-path=/usr/local/google/home/dandye/.ssh/malachite-787fa7323a7d_bk_and_ing.json \
+  --timestamp-delta=1d
 ```
 
 ### Customer ID
@@ -66,10 +66,10 @@ The image below shows that original timestamps on 2023-06-23 (top two subplots) 
 When timestamp_delta is set to 0d (zero days), only year, month, and day are updated (to today) and the hours, minutes, seconds, and milliseconds are preserved. That hour may be in the future, so when timestamp_delta is set to 1d the year, month, and day are set to today minus 1 day and the hours, minutes, seconds, and milliseconds are preserved.
 
 ```{tip}
-For best results, use a cron jobs to run the usecase daily at 12:01am with `--timestamp_delta=1d`.
+For best results, use a cron jobs to run the usecase daily at 12:01am with `--timestamp-delta=1d`.
 ```
 
-You may also provide `Nh` for offsetting by the hour, which is mainly useful if you want to replay the same log file multiple times per day (and prevend deduplication). Likewise, `Nm` offsets by minutes. These can be combined. For example, on the day of writing (Dec 13, 2024)`--timestamp_delta=1d1h1m` changes an original timestamp from/to:
+You may also provide `Nh` for offsetting by the hour, which is mainly useful if you want to replay the same log file multiple times per day (and prevent deduplication). Likewise, `Nm` offsets by minutes. These can be combined. For example, on the day of writing (Dec 13, 2024)`--timestamp-delta=1d1h1m` changes an original timestamp from/to:
 ```
 2021-12-01T13:37:42.123Z1
 2024-12-12T12:36:42.123Z1
@@ -134,23 +134,32 @@ LogStory automatically validates timestamp configurations at runtime to ensure:
 
 If configuration validation fails, LogStory will provide clear error messages indicating the specific log type, timestamp, and issue found.
 
-## Flags and flag files
+## Command Structure
 
-Assuming your flagfile is named config.cfg, you can use it to define all of the required flags and then invoke with:
-
-```
-logstory usecase_replay_logtype RULES_SEARCH_WORKSHOP POWERSHELL --flagfile=config.cfg
-```
-
-That updates timestamps and all uploads from a single logfile in a single usecase. The following updates timestamps and uploads only entities (rather than events) from and overrides the timestamp_delta in the flagfile (if it is specified):
+Logstory uses a modern CLI structure with command groups. You can replay specific logtypes like this:
 
 ```
-logstory usecase_replay_logtype RULES_SEARCH_WORKSHOP POWERSHELL --flagfile=config.cfg --timestamp_delta=0d --entities
+logstory replay logtype RULES_SEARCH_WORKSHOP POWERSHELL \
+  --customer-id=01234567-0123-4321-abcd-01234567890a \
+  --credentials-path=/path/to/credentials.json
 ```
 
-You can increase verbocity with by prepending the python log level:
+That updates timestamps and uploads from a single logfile in a single usecase. The following updates timestamps and uploads only entities (rather than events):
+
 ```
-PYTHONLOGLEVEL=DEBUG logstory usecase_replay RULES_SEARCH_WORKSHOP --flagfile=config.cfg --timestamp_delta=0d
+logstory replay logtype RULES_SEARCH_WORKSHOP POWERSHELL \
+  --customer-id=01234567-0123-4321-abcd-01234567890a \
+  --credentials-path=/path/to/credentials.json \
+  --timestamp-delta=0d \
+  --entities
+```
+
+You can increase verbosity by prepending the python log level:
+```
+PYTHONLOGLEVEL=DEBUG logstory replay usecase RULES_SEARCH_WORKSHOP \
+  --customer-id=01234567-0123-4321-abcd-01234567890a \
+  --credentials-path=/path/to/credentials.json \
+  --timestamp-delta=0d
 ```
 
 For more usage, see `logstory --help`
@@ -194,16 +203,15 @@ gs://logstory-usecases-20241216/EDR_WORKSHOP \
 
 To make that easier:
 ```
-❯ logstory usecases_list_available
+❯ logstory usecases list-available
 
 Available usecases in bucket 'logstory-usecases-20241216':
 - EDR_WORKSHOP
 - RULES_SEARCH_WORKSHOP
-['EDR_WORKSHOP', 'RULES_SEARCH_WORKSHOP']
 ```
 
 ```
-❯ logstory usecase_get EDR_WORKSHOP
+❯ logstory usecases get EDR_WORKSHOP
 
 Available usecases in bucket 'logstory-usecases-20241216':
 - EDR_WORKSHOP
@@ -215,9 +223,7 @@ Downloading EDR_WORKSHOP/EVENTS/WINDOWS_SYSMON.log to [redacted]/logstory/src/lo
 ```
 
 ```
-❯ logstory usecase_list
-Unknown command: usecase_list
-❯ logstory usecases_list
+❯ logstory usecases list-installed
 #
 # EDR_WORKSHOP
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logstory"
-version = "0.1.4"
+version = "0.2.0"
 authors = [
   { name = "Google Cloud Security" },
 ]
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "absl-py == 2.1",
+    "typer[all] >= 0.12.0",
     "google-cloud-storage == 2.10",
     "google-cloud-secret-manager ~= 2.16.0", # Updated version
     "setuptools >= 61.0", # Added setuptools
@@ -25,6 +25,7 @@ dependencies = [
     "google-auth == 2.23",
     "oyaml >= 1.0",
     "requests ~= 2.32.3",
+    "python-dotenv >= 1.0.0",
 ]
 
 [project.urls]

--- a/src/logstory/logstory.py
+++ b/src/logstory/logstory.py
@@ -16,85 +16,145 @@
 import datetime
 import glob
 import os
-import sys
 import uuid
 
-from absl import app, flags
+import typer
+from dotenv import load_dotenv
 from google.cloud import storage
 from google.oauth2 import service_account
 
 UTC = datetime.UTC
 
+# Create Typer app and command groups
+app = typer.Typer(help="Logstory: Replay SecOps logs with updated timestamps")
+usecases_app = typer.Typer(help="Manage and list usecases")
+replay_app = typer.Typer(help="Replay log data")
 
-# Validation function to check if the string is a valid UUID4
-def is_valid_uuid4(value):
-  """Abseil flag validation for customer id."""
+app.add_typer(usecases_app, name="usecases")
+app.add_typer(replay_app, name="replay")
+
+
+def validate_uuid4(value: str) -> str:
+  """Typer callback validation for customer ID."""
   try:
     val = uuid.UUID(value, version=4)
-    # Check if the string conforms to the UUID4 format
-    return str(val) == value
-  except ValueError:
-    return False
+    if str(val) == value:
+      return value
+    raise typer.BadParameter(f"'{value}' is not a valid UUID4")
+  except ValueError as e:
+    raise typer.BadParameter(f"'{value}' is not a valid UUID4") from e
 
 
-def validate_service_account_json(json_path):
-  """Abseil flag validation for credentials file."""
-  # Check if the file exists
-  if not os.path.isfile(json_path):
-    raise FileNotFoundError(
-        f"File does not exist: {json_path}.\n"
-        "Please provide the complete path to a JSON credentials file.\n"
+def validate_credentials_file(value: str) -> str:
+  """Typer callback validation for credentials file."""
+  if not os.path.isfile(value):
+    raise typer.BadParameter(
+        f"File does not exist: {value}. "
+        "Please provide the complete path to a JSON credentials file."
     )
   try:
-    # Attempt to load the service account credentials
-    _ = service_account.Credentials.from_service_account_file(json_path)
-    # If it loads successfully, the path is valid
-    return True, "The JSON file is valid."
+    _ = service_account.Credentials.from_service_account_file(value)
+    return value
   except Exception as e:
-    # If an error occurs, return False and the error message
-    # pylint: disable-next=broad-exception-raised
-    raise Exception(f"The JSON file is invalid: {e}") from e
+    raise typer.BadParameter(f"The JSON file is invalid: {e}") from e
 
 
-FLAGS = flags.FLAGS
-flags.DEFINE_string(
-    "credentials_path",
+def load_env_file(env_file: str | None = None) -> None:
+  """Load environment variables from .env file."""
+  if env_file:
+    if not os.path.isfile(env_file):
+      typer.echo(f"Warning: Specified .env file not found: {env_file}")
+      return
+    load_dotenv(env_file)
+    typer.echo(f"Loaded environment from: {env_file}")
+  # Try to load default .env file if it exists
+  elif os.path.isfile(".env"):
+    load_dotenv(".env")
+    typer.echo("Loaded environment from: .env")
+
+
+# Global options for replay commands
+def get_credentials_default():
+  """Get credentials path from environment variable."""
+  return os.getenv("LOGSTORY_CREDENTIALS_PATH")
+
+
+def get_customer_id_default():
+  """Get customer ID from environment variable."""
+  return os.getenv("LOGSTORY_CUSTOMER_ID")
+
+
+def get_region_default():
+  """Get region from environment variable."""
+  return os.getenv("LOGSTORY_REGION", "US")
+
+
+CredentialsOption = typer.Option(
     None,
-    "Path to JSON credentials for Ingestion API Service account.",
-    short_name="c",
-    required=False,  # conditionally req. depending on subcommand
+    "--credentials-path",
+    "-c",
+    help=(
+        "Path to JSON credentials for Ingestion API Service account (env:"
+        " LOGSTORY_CREDENTIALS_PATH)"
+    ),
+    callback=lambda v: validate_credentials_file(v) if v else None,
 )
-flags.DEFINE_string(
-    "customer_id",
+
+CustomerIdOption = typer.Option(
     None,
-    "Customer ID for SecOps instance, found on `/settings/profile/`.",
-    required=False,  # conditionally req. depending on subcommand
+    "--customer-id",
+    help=(
+        "Customer ID for SecOps instance, found on `/settings/profile/` (env:"
+        " LOGSTORY_CUSTOMER_ID)"
+    ),
+    callback=lambda v: validate_uuid4(v) if v else None,
 )
-flags.DEFINE_string(
-    "region",
-    None,  # "US" (default) is a regionless base url, so None works here.
-    "SecOps tenant's region (Default=US). Used to set ingestion API base URL.",
-    short_name="r",
-    required=False,
-)
-flags.DEFINE_bool("entities", False, "Load Entities instead of Events")
-flags.DEFINE_bool("three_day", False, "Load Entities instead of Events")
-flags.DEFINE_string(
-    "timestamp_delta",
+
+EnvFileOption = typer.Option(
     None,
-    "Determines how datetimes in logfiles are updated. "
-    "It is expressed in any/all: days, hours, minutes (d, h, m) (Default=1d) "
-    "Examples: [1d, 1d1h, 1h1m, 1d1m, 1d1h1m, 1m1h, ...] "
-    "Setting only `Nd` preserves the original HH:MM:SS but updates date. "
-    "Nh/Nm subtracts an additional offset from that datetime, to facilitate "
-    "running logstory more than 1x per day. ",
-    required=False,
+    "--env-file",
+    help="Path to .env file to load environment variables from",
 )
-flags.DEFINE_string(
-    "usecases_bucket",
-    "logstory-usecases-20241216",  # default public bucket with usecases
-    "GCP Cloud Storage bucket with additional usecases.",
-    required=False,
+
+RegionOption = typer.Option(
+    None,
+    "--region",
+    "-r",
+    help=(
+        "SecOps tenant's region (Default=US). Used to set ingestion API base URL (env:"
+        " LOGSTORY_REGION)"
+    ),
+)
+
+EntitiesOption = typer.Option(
+    False,
+    "--entities",
+    help="Load Entities instead of Events",
+)
+
+ThreeDayOption = typer.Option(
+    False,
+    "--three-day",
+    help="Use 3-day configuration",
+)
+
+TimestampDeltaOption = typer.Option(
+    None,
+    "--timestamp-delta",
+    help=(
+        "Determines how datetimes in logfiles are updated. "
+        "Expressed in any/all: days, hours, minutes (d, h, m) (Default=1d). "
+        "Examples: [1d, 1d1h, 1h1m, 1d1m, 1d1h1m, 1m1h, ...]. "
+        "Setting only `Nd` preserves the original HH:MM:SS but updates date. "
+        "Nh/Nm subtracts an additional offset from that datetime, to facilitate "
+        "running logstory more than 1x per day."
+    ),
+)
+
+UsecasesBucketOption = typer.Option(
+    "logstory-usecases-20241216",
+    "--usecases-bucket",
+    help="GCP Cloud Storage bucket with additional usecases",
 )
 
 
@@ -103,65 +163,70 @@ def _get_current_time():
   return datetime.datetime.now(UTC)
 
 
-def usecases_list_logtypes():
-  usecases_list(print_logtypes=True)
+@usecases_app.command("list-installed")
+def usecases_list(
+    logtypes: bool = typer.Option(
+        False, "--logtypes", help="Show logtypes for each usecase"
+    ),
+    details: bool = typer.Option(
+        False, "--details", help="Show full markdown content for each usecase"
+    ),
+    open_usecase: str = typer.Option(
+        None, "--open", help="Open markdown file for specified usecase in VS Code"
+    ),
+    entities: bool = EntitiesOption,
+):
+  """List locally installed usecases and optionally their logtypes."""
+  # Handle --open flag as a special case
+  if open_usecase:
+    import subprocess
 
-
-def get_usecases():
-  """NOTE: this is *all* usecases, not just enabled in `events-24h`"""
-  usecase_dirs = glob.glob(
-      os.path.join(os.path.dirname(os.path.abspath(__file__)), "usecases/*")
-  )
-  usecases = []
-  for usecase_dir in usecase_dirs:
-    parts = os.path.split(usecase_dir)
-    usecases.append(parts[-1])
-  return usecases
-
-
-def _get_blobs(bucket_name, usecase=None):
-  client = storage.Client.create_anonymous_client()
-  bucket = client.bucket(bucket_name)
-  if usecase:
-    blobs = bucket.list_blobs(prefix=usecase)
-  else:
-    blobs = bucket.list_blobs(delimiter="/")
-  return blobs
-
-
-def list_bucket_directories(bucket_name):
-  """Lists the top-level directories in a GCP bucket."""
-  blobs = _get_blobs(bucket_name)
-  top_level_directories = []
-  print(f"\nAvailable usecases in bucket '{bucket_name}':")
-  for blob in blobs.pages:
-    prefixes = blob.prefixes
-    for prefix in prefixes:
-      if "docs" in prefix:
-        continue
-      prefix = prefix.strip("/")
-      print(f"- {prefix}")
-      top_level_directories.append(prefix)
-  return top_level_directories
-
-
-def usecase_get(bucket_name, usecase):
-  """Download usecase from GCP bucket."""
-  blob_list = _get_blobs(bucket_name, usecase)
-  for blob in blob_list:
-    if blob.name.endswith("/"):
-      continue
-    destination_file_name = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "usecases/", blob.name
+    usecase_dirs = glob.glob(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "usecases/*")
     )
-    os.makedirs(os.path.dirname(destination_file_name), exist_ok=True)
-    print(f"Downloading {blob.name} to {destination_file_name}")
-    blob.download_to_filename(destination_file_name)
 
+    # Find the specified usecase
+    usecase_found = False
+    for usecase_dir in usecase_dirs:
+      parts = os.path.split(usecase_dir)
+      if parts[-1] == open_usecase:
+        usecase_found = True
+        # Look for markdown files in this usecase
+        md_files = glob.glob(os.path.join(usecase_dir, "*.md"))
+        if md_files:
+          for md_file in md_files:
+            typer.echo(f"Opening {md_file} in VS Code...")
+            try:
+              subprocess.run(["code", md_file], check=True)
+            except subprocess.CalledProcessError:
+              typer.echo(
+                  "Error: Could not run 'code' command. Make sure VS Code is installed"
+                  " and in PATH."
+              )
+              raise typer.Exit(1)
+            except FileNotFoundError:
+              typer.echo(
+                  "Error: 'code' command not found. Make sure VS Code is installed and"
+                  " in PATH."
+              )
+              raise typer.Exit(1)
+        else:
+          typer.echo(f"No markdown files found in usecase '{open_usecase}'")
+          raise typer.Exit(1)
+        break
 
-# Define subcommands
-def usecases_list(print_logtypes=False, entities=False):
-  """Walk the usecases/ dir and print the dir names."""
+    if not usecase_found:
+      available_usecases = [
+          os.path.split(d)[-1]
+          for d in usecase_dirs
+          if os.path.split(d)[-1] not in ["__init__.py", "AWS"]
+      ]
+      typer.echo(f"Error: Usecase '{open_usecase}' not found.")
+      typer.echo(f"Available usecases: {', '.join(sorted(available_usecases))}")
+      raise typer.Exit(1)
+
+    return  # Exit early when using --open
+
   entity_or_event = "ENTITIES" if entities else "EVENTS"
   usecase_dirs = glob.glob(
       os.path.join(os.path.dirname(os.path.abspath(__file__)), "usecases/*")
@@ -178,236 +243,292 @@ def usecases_list(print_logtypes=False, entities=False):
     for md in glob.glob(os.path.join("./", usecase_dir, "*.md")):
       markdown_map[usecases[-1]].append(md)
     log_types = []
-    if print_logtypes:
+    if logtypes:
       for adir in glob.glob(os.path.join("./", usecase_dir, entity_or_event, "*.log")):
         log_types.append(os.path.splitext(os.path.split(adir)[-1])[0])
       logypes_map[usecases[-1]] = log_types
   for usecase in sorted(usecases):
-    print(f"#\n# {usecase}\n#")
-    for md in markdown_map.get(usecase, []):
-      with open(md) as fh:
-        print(fh.read())
-    if print_logtypes:
+    if details:
+      print(f"#\n# {usecase}\n#")
+      for md in markdown_map.get(usecase, []):
+        with open(md) as fh:
+          print(fh.read())
+    else:
+      print(usecase)
+
+    if logtypes:
       for log_type in sorted(logypes_map[usecase]):
-        print(f"\t{log_type}")
+        if details:
+          print(f"\t{log_type}")
+        else:
+          print(f"  {log_type}")
 
 
-def get_logtypes(usecase, entities=False):
-  """Walk the subdirs in usecases and print the file base names."""
-  print(f"Executing usecase: {usecase}")
-  # Access common flags with FLAGS.flag_name
+def _get_blobs(bucket_name, usecase=None):
+  client = storage.Client.create_anonymous_client()
+  bucket = client.bucket(bucket_name)
+  if usecase:
+    blobs = bucket.list_blobs(prefix=usecase)
+  else:
+    blobs = bucket.list_blobs(delimiter="/")
+  return blobs
 
+
+@usecases_app.command("list-available")
+def list_bucket_directories(
+    bucket: str = UsecasesBucketOption,
+):
+  """List usecases available for download from GCP bucket."""
+  bucket_name = bucket
+  blobs = _get_blobs(bucket_name)
+  top_level_directories = []
+  print(f"\nAvailable usecases in bucket '{bucket_name}':")
+  for blob in blobs.pages:
+    prefixes = blob.prefixes
+    for prefix in prefixes:
+      if "docs" in prefix:
+        continue
+      prefix = prefix.strip("/")
+      print(f"- {prefix}")
+      top_level_directories.append(prefix)
+  return top_level_directories
+
+
+def _get_bucket_directories(bucket_name: str) -> list[str]:
+  """Helper function to get bucket directories without printing."""
+  blobs = _get_blobs(bucket_name)
+  top_level_directories = []
+  for blob in blobs.pages:
+    prefixes = blob.prefixes
+    for prefix in prefixes:
+      if "docs" in prefix:
+        continue
+      prefix = prefix.strip("/")
+      top_level_directories.append(prefix)
+  return top_level_directories
+
+
+@usecases_app.command("get")
+def usecase_get(
+    usecase: str = typer.Argument(..., help="Name of the usecase to download"),
+    bucket: str = UsecasesBucketOption,
+):
+  """Download a usecase from GCP bucket."""
+  bucket_name = bucket
+
+  # Validate usecase exists in bucket
+  available_usecases = _get_bucket_directories(bucket_name)
+  if usecase not in available_usecases:
+    typer.echo(f"Error: Usecase '{usecase}' not found in bucket '{bucket_name}'")
+    available = ", ".join(available_usecases)
+    typer.echo(f"Available usecases: {available}")
+    raise typer.Exit(1)
+  blob_list = _get_blobs(bucket_name, usecase)
+  for blob in blob_list:
+    if blob.name.endswith("/"):
+      continue
+    destination_file_name = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "usecases/", blob.name
+    )
+    os.makedirs(os.path.dirname(destination_file_name), exist_ok=True)
+    print(f"Downloading {blob.name} to {destination_file_name}")
+    blob.download_to_filename(destination_file_name)
+
+
+def _get_logtypes(usecase: str, entities: bool = False) -> list[str]:
+  """Get logtype names for a usecase without printing."""
   entity_or_event = "ENTITIES" if entities else "EVENTS"
   usecase_dir = f"{os.path.split(__file__)[0]}/usecases/{usecase}/{entity_or_event}/"
   log_files = glob.glob(usecase_dir + "*.log")
   log_types = []
   for log_file in log_files:
-    print(f"log_file: {log_file}")
     parts = os.path.split(log_file)
     log_type = os.path.splitext(parts[-1])[0]
     log_types.append(log_type)
-    print(f"log_type: {log_type}")
   return log_types
 
 
-def local_main(argv):
-  """Parse args and call the appropriate function."""
-  if len(argv) < 2:
-    custom_help()
-    return 1
-  # parse the flags
-  FLAGS(argv)
-  # Some params are conditionally required
-  # Check if either "usecase_replay" or "usecase_replay_logtype" is in argv
-  requires_customer_and_credentials = any(
-      arg in argv for arg in ["usecase_replay", "usecase_replay_logtype"]
+def get_usecases() -> list[str]:
+  """Get all available usecases."""
+  usecase_dirs = glob.glob(
+      os.path.join(os.path.dirname(os.path.abspath(__file__)), "usecases/*")
   )
-  # Check if customer_id or credentials_path is missing
-  missing_customer_or_credentials = not FLAGS.customer_id or not FLAGS.credentials_path
-  # Combine the conditions
-  if requires_customer_and_credentials and missing_customer_or_credentials:
-    # Handle the case where either customer_id or credential_path is missing
-    raise ValueError(
-        "The following flags must be set when using the usecase_replay and"
-        " usecases_list_logtypes subcommands:\n\t--credentials_path,"
-        " --customer_id, ..."
+  usecases = []
+  for usecase_dir in usecase_dirs:
+    parts = os.path.split(usecase_dir)
+    usecases.append(parts[-1])
+  return usecases
+
+
+def _load_and_validate_params(
+    env_file: str | None,
+    credentials_path: str | None,
+    customer_id: str | None,
+    region: str | None,
+) -> tuple[str, str, str]:
+  """Load environment file and validate/resolve required parameters."""
+  # Load environment file first
+  load_env_file(env_file)
+
+  # Resolve parameters using environment variables as fallback
+  final_credentials = credentials_path or get_credentials_default()
+  final_customer_id = customer_id or get_customer_id_default()
+  final_region = region or get_region_default()
+
+  # Validate required parameters
+  if not final_credentials or not final_customer_id:
+    missing = []
+    if not final_credentials:
+      missing.append("--credentials-path (or LOGSTORY_CREDENTIALS_PATH)")
+    if not final_customer_id:
+      missing.append("--customer-id (or LOGSTORY_CUSTOMER_ID)")
+
+    typer.echo(f"Error: Missing required parameters: {', '.join(missing)}")
+    typer.echo("You can provide these via:")
+    typer.echo("  1. Command line options: --credentials-path and --customer-id")
+    typer.echo(
+        "  2. Environment variables: LOGSTORY_CREDENTIALS_PATH and LOGSTORY_CUSTOMER_ID"
     )
+    typer.echo("  3. .env file with --env-file option")
+    raise typer.Exit(1)
 
-  # optionality was determined above. now validate if the params are present.
-  if FLAGS.credentials_path:
-    flags.register_validator(
-        "credentials_path",
-        validate_service_account_json,
-        message="--credentials_path must be JSON credentials for a Service Account",
-    )
-  if FLAGS.customer_id:
-    flags.register_validator(
-        "customer_id",
-        is_valid_uuid4,
-        message="--customer_id must be a UUID4",
-    )
-  # must parse flags again to enforce validators
-  FLAGS(argv)
+  # Additional validation
+  if final_credentials:
+    final_credentials = validate_credentials_file(final_credentials)
+  if final_customer_id:
+    final_customer_id = validate_uuid4(final_customer_id)
 
-  # if present and valid, set as env vars
-  if FLAGS.customer_id:
-    os.environ["CUSTOMER_ID"] = FLAGS.customer_id
-    print(f"The customer_id is: {os.environ['CUSTOMER_ID']}")
+  return final_credentials, final_customer_id, final_region
 
-  if FLAGS.credentials_path:
-    os.environ["CREDENTIALS_PATH"] = FLAGS.credentials_path
-    print(f"The credentials_path is: {os.environ['CREDENTIALS_PATH']}")
 
-  # should us -> '' logic be here or in the main.py file?
-  if FLAGS.region:
-    os.environ["REGION"] = FLAGS.region
+def _set_environment_vars(
+    credentials_path: str | None,
+    customer_id: str | None,
+    region: str | None,
+):
+  """Set environment variables from CLI parameters."""
+  if customer_id:
+    os.environ["CUSTOMER_ID"] = customer_id
+    typer.echo(f"Customer ID: {customer_id}")
 
-  if len(argv) < 2:
-    print("Usage: %s {usecases_list, command_two} [options]" % argv[0])
-    return 1
-  command = argv[1]
-  if command == "usecases_list":
-    return usecases_list()
-  if command == "usecases_list_logtypes":
-    return usecases_list_logtypes()
-  if command == "usecases_list_available":
-    return list_bucket_directories(FLAGS.usecases_bucket)
-  if command == "usecase_get":
-    usecase = argv[2]  # flaky?
-    if not usecase:
-      raise ValueError("Missing usecase argument for usecase_get")
-    if usecase not in list_bucket_directories(FLAGS.usecases_bucket):
-      raise ValueError(
-          f"Usecase '{usecase}' not found in bucket '{FLAGS.usecases_bucket}'"
-      )
+  if credentials_path:
+    os.environ["CREDENTIALS_PATH"] = credentials_path
+    typer.echo(f"Credentials path: {credentials_path}")
 
-    return usecase_get(FLAGS.usecases_bucket, usecase)
+  if region:
+    os.environ["REGION"] = region
 
-  # late import here due to globals in the module
+
+@replay_app.command("all")
+def replay_all_usecases(
+    env_file: str | None = EnvFileOption,
+    credentials_path: str | None = CredentialsOption,
+    customer_id: str | None = CustomerIdOption,
+    region: str | None = RegionOption,
+    entities: bool = EntitiesOption,
+    timestamp_delta: str | None = TimestampDeltaOption,
+):
+  """Replay all usecases."""
+  final_credentials, final_customer_id, final_region = _load_and_validate_params(
+      env_file, credentials_path, customer_id, region
+  )
+  _set_environment_vars(final_credentials, final_customer_id, final_region)
+
+  usecases = get_usecases()
+  _replay_usecases(usecases, "*", entities, timestamp_delta)
+
+
+@replay_app.command("usecase")
+def replay_usecase(
+    usecase: str = typer.Argument(..., help="Name of the usecase to replay"),
+    env_file: str | None = EnvFileOption,
+    credentials_path: str | None = CredentialsOption,
+    customer_id: str | None = CustomerIdOption,
+    region: str | None = RegionOption,
+    entities: bool = EntitiesOption,
+    timestamp_delta: str | None = TimestampDeltaOption,
+):
+  """Replay a specific usecase."""
+  final_credentials, final_customer_id, final_region = _load_and_validate_params(
+      env_file, credentials_path, customer_id, region
+  )
+  _set_environment_vars(final_credentials, final_customer_id, final_region)
+
+  usecases = [usecase]
+  logtypes = _get_logtypes(usecase, entities=entities)
+  _replay_usecases(usecases, logtypes, entities, timestamp_delta)
+
+
+@replay_app.command("logtype")
+def replay_usecase_logtype(
+    usecase: str = typer.Argument(..., help="Name of the usecase"),
+    logtypes: str = typer.Argument(..., help="Comma-separated list of logtypes"),
+    env_file: str | None = EnvFileOption,
+    credentials_path: str | None = CredentialsOption,
+    customer_id: str | None = CustomerIdOption,
+    region: str | None = RegionOption,
+    entities: bool = EntitiesOption,
+    timestamp_delta: str | None = TimestampDeltaOption,
+):
+  """Replay specific logtypes from a usecase."""
+  final_credentials, final_customer_id, final_region = _load_and_validate_params(
+      env_file, credentials_path, customer_id, region
+  )
+  _set_environment_vars(final_credentials, final_customer_id, final_region)
+
+  usecases = [usecase]
+  logtype_list = [lt.strip() for lt in logtypes.split(",")]
+  _replay_usecases(usecases, logtype_list, entities, timestamp_delta)
+
+
+def _replay_usecases(
+    usecases: list[str],
+    logtypes: list[str] | str,
+    entities: bool,
+    timestamp_delta: str | None,
+):
+  """Core replay logic shared by replay commands."""
+  # Late import to avoid circular imports
   try:
     from . import main as imported_main
   except ImportError:
     import main as imported_main
 
-  if command == "usecases_replay":
-    usecases = get_usecases()
-    logtypes = "*"
-  elif command == "usecase_replay":
-    usecase = argv[2]  # flaky?
-    usecases = [
-        usecase,
-    ]
-    logtypes = get_logtypes(usecase, entities=FLAGS.entities)
-  elif command == "usecase_replay_logtype":
-    usecase = argv[2]  # flaky?
-    usecases = [
-        usecase,
-    ]
-    logtypes = argv[3].split(",")
-  else:
-    print("Unknown command: %s" % command)
-    return 1
+  logstory_exe_time = _get_current_time()
 
-  logstory_exe_time = datetime.datetime.now(datetime.UTC)
   for use_case in usecases:
-    logstory_exe_time = _get_current_time()
-    if command == "usecases_replay":
-      logtypes = get_logtypes(use_case)
+    if logtypes == "*":
+      current_logtypes = _get_logtypes(use_case, entities=entities)
+    else:
+      current_logtypes = logtypes
 
-    old_base_time = None  # resets for each usecase
-    for log_type in logtypes:
-      old_base_time = None  # resets for each log_type
+    old_base_time = None
+    for log_type in current_logtypes:
+      old_base_time = None
       log_type = log_type.strip()
-      print(f"usecase: {use_case}")
-      print(f"{logtypes}, |{log_type}|")
+      typer.echo(f"Processing usecase: {use_case}, logtype: {log_type}")
+
       old_base_time = imported_main.usecase_replay_logtype(
           use_case,
           log_type,
           logstory_exe_time,
           old_base_time,
-          timestamp_delta=FLAGS.timestamp_delta or None,
-          entities=FLAGS.entities,
+          timestamp_delta=timestamp_delta,
+          entities=entities,
       )
-    print(f"""UDM Search for the loaded logs:
+
+    typer.echo(f"""UDM Search for the loaded logs:
     metadata.ingested_timestamp.seconds >= {int(logstory_exe_time.timestamp())}
     metadata.ingestion_labels["log_replay"]="true"
     metadata.ingestion_labels["replayed_from"]="logstory"
     metadata.ingestion_labels["usecase_name"]="{use_case}"
-    """)  # ToDo: get upper bound of ingested and print it?
-
-  return "Success Events!"
-
-
-def custom_help():
-  help_text = """
-    Usage: logstory <command> [command options]
-
-    Commands:
-      usecases_list            List the usecases
-
-      usecases_list_logtypes   List each logtype for each usecase
-
-      usecases_list_available  List usecases that can be downloaded
-
-      usecase_get              Download usecase from GCP bucket
-
-      usecases_replay          Replay all usecases
-
-      usecase_replay           Replay a specific usecase
-         examples:
-           usecase_replay NETWORK_ANALYSIS
-           usecase_replay RULES_SEARCH_WORKSHOP
-           ...
-
-      usecase_replay_logtype   Replay a specific usecase with a specific log type
-         examples:
-           usecase_replay_logtype RULES_SEARCH_WORKSHOP POWERSHELL
-           usecase_replay_logtype RULES_SEARCH_WORKSHOP WINEVETLOG
-           usecase_replay_logtype RULES_SEARCH_WORKSHOP POWERSHELL,WINEVETLOG # No spaces without quotes
-           usecase_replay_logtype RULES_SEARCH_WORKSHOP "POWERSHELL, WINEVETLOG" # Use quotes if there are spaces
-           ...
-
-      usecase_get EDR_WORKSHOP
-
-    Usage Examples:
-      logstory usecases_list
-
-      logstory usecases_list_logtypes
-
-      logstory usecases_replay --flagfile=config.cfg
-
-      logstory usecase_replay NETWORK_ANALYSIS --flagfile=config.cfg
-      logstory usecase_replay NETWORK_ANALYSIS --flagfile=config.cfg --timestamp_delta=1d
-      logstory usecase_replay NETWORK_ANALYSIS --flagfile=config.cfg --timestamp_delta=1d1h
-      logstory usecase_replay NETWORK_ANALYSIS --flagfile=config.cfg --timestamp_delta=1d1h1m
-      logstory usecase_replay NETWORK_ANALYSIS --flagfile=config.cfg --timestamp_delta=1h30m
-
-      logstory usecase_replay_logtype RULES_SEARCH_WORKSHOP POWERSHELL,WINEVETLOG --flagfile=config.cfg
-      logstory usecase_replay_logtype RULES_SEARCH_WORKSHOP "POWERSHELL, WINEVETLOG" --flagfile=config.cfg
-
-      # change loglevel and tee output to a file
-      PYTHONLOGLEVEL=debug logstory ... | tee "logstory_exe_$(date +%Y%m%d_%H%M%S).log"
-
-      # Entities
-      logstory usecase_replay NETWORK_ANALYSIS --flagfile=config.cfg --timestamp_delta=1d --entities
-
-      logstory usecase_replay_logtype NETWORK_ANALYSIS WIONDOWS_AD --flagfile=config.cfg --entities
-
-      logstory usecase_get EDR_WORKSHOP
-    """
-  print(help_text)
-  print(FLAGS)
+    """)
 
 
 def entry_point():
-  if "--help" in sys.argv:
-    custom_help()
-    sys.exit(1)
-  app.run(local_main)  # evaluates the flags
+  """Main entry point for the CLI."""
+  app()
 
 
 if __name__ == "__main__":
-  if "--help" in sys.argv:
-    custom_help()
-    sys.exit(1)
-  app.run(local_main)  # evaluates the flags
+  app()


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: Complete migration from Abseil to Typer CLI framework
- Restructured command organization with logical groups: `usecases` and `replay`
- Added comprehensive environment file support with `--env-file` option
- Enhanced user experience with progressive disclosure and VS Code integration

## Key Changes

### CLI Framework Migration
- **Breaking**: Commands now use groups: `logstory usecases COMMAND` and `logstory replay COMMAND`
- Replaced Abseil with modern Typer framework for better help generation and validation
- Updated flag naming convention to use hyphens (e.g., `--customer-id` instead of `--customer_id`)
- Improved error messages and parameter validation

### Environment Configuration Support
- Added `--env-file` option to specify custom environment files (`.env.prod`, `.env.dev`, etc.)
- Support for environment variables: `LOGSTORY_CUSTOMER_ID`, `LOGSTORY_CREDENTIALS_PATH`, `LOGSTORY_REGION`
- Automatic loading of default `.env` file if present
- Configuration priority: CLI options > environment variables > .env file values

### Enhanced User Experience
- Added `--details` flag for progressive disclosure in `list-installed` command (defaults to names-only)
- Added `--open` flag to open usecase markdown files directly in VS Code
- Comprehensive help text with environment variable hints
- Better command organization and discoverability

### Documentation Updates
- Updated README.md with complete CLI reference and environment file examples
- Added migration guide for users upgrading from Abseil CLI
- Updated docs/index.md with new command structure
- Updated CHANGELOG.md with breaking changes documentation

## Migration Guide

| Old Command | New Command |
|-------------|-------------|
| `logstory usecases_list` | `logstory usecases list-installed` |
| `logstory usecases_list_logtypes` | `logstory usecases list-installed --logtypes` |
| `logstory usecase_replay X` | `logstory replay usecase X` |

## Usage Examples

### Environment File Support
```bash
# Create environment files for different environments
echo "LOGSTORY_CUSTOMER_ID=prod-uuid" > .env.prod
echo "LOGSTORY_CUSTOMER_ID=dev-uuid" > .env.dev

# Use specific environment
logstory replay usecase RULES_SEARCH_WORKSHOP --env-file .env.prod
```

### Progressive Disclosure
```bash
# Simple list (new default)
logstory usecases list-installed

# With logtypes
logstory usecases list-installed --logtypes

# Full details (old default behavior)
logstory usecases list-installed --details
```

## Test Plan
- [x] Basic CLI functionality works with new command structure
- [x] Environment file loading works with custom paths
- [x] Environment variables are properly resolved with correct priority
- [x] Help text is clear and informative
- [x] Migration examples in documentation are accurate
- [x] VS Code integration works with `--open` flag
- [ ] All existing functionality preserved through migration
- [ ] Pre-commit hooks pass (some linting issues to address)

## Notes
- This is a draft PR to gather feedback on the approach
- Some pre-commit hook issues need to be resolved (security warnings for subprocess usage)
- Version bump included in pyproject.toml (0.1.4 → 0.2.0) to reflect breaking changes